### PR TITLE
Parsing boolean expressions with the QueryBuilder

### DIFF
--- a/Dapper.Extensions.Linq.Test/Dapper.Extensions.Linq.Test.csproj
+++ b/Dapper.Extensions.Linq.Test/Dapper.Extensions.Linq.Test.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Configuration\Container.cs" />
     <Compile Include="Helpers\DatabaseInfo.cs" />
     <Compile Include="Helpers\Protected.cs" />
+    <Compile Include="IntegrationTests\Fixtures\QueryBuilder.cs" />
     <Compile Include="IntegrationTests\Fixtures\Global.cs" />
     <Compile Include="IntegrationTests\Fixtures\Methods.cs" />
     <Compile Include="IntegrationTests\Fixtures\Count.cs" />

--- a/Dapper.Extensions.Linq.Test/IntegrationTests/Fixtures/QueryBuilder.cs
+++ b/Dapper.Extensions.Linq.Test/IntegrationTests/Fixtures/QueryBuilder.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq.Expressions;
+using Castle.Windsor;
+using Dapper.Extensions.Linq.Builder;
+using Dapper.Extensions.Linq.CastleWindsor;
+using Dapper.Extensions.Linq.Core.Configuration;
+using Dapper.Extensions.Linq.Mapper;
+using Dapper.Extensions.Linq.SQLite;
+using Dapper.Extensions.Linq.Test.Entities;
+using NUnit.Framework;
+
+namespace Dapper.Extensions.Linq.Test.IntegrationTests.Fixtures
+{
+    public class QueryBuilderTest
+    {
+        private IWindsorContainer Container { get; set; }
+
+        [TestFixtureSetUp]
+        public void RunBeforeAnyTests()
+        {
+            Container = new Castle.Windsor.WindsorContainer();
+
+            DapperConfiguration
+                .Use()
+                .UseClassMapper(typeof(AutoClassMapper<>))
+                .UseContainer<ContainerForWindsor>(cfg => cfg.UseExisting(Container))
+                .UseSqlDialect(new SQLiteDialect())
+                .FromAssembly("Dapper.Extensions.Linq.Test.Entities")
+                .Build();
+        }
+
+        [Test]
+        public void QueryBuilder_BooleanTrue()
+        {
+            Expression<Func<Person, bool>> expression = e => e.Id == 14 && e.Active;
+
+            QueryBuilder<Person>.FromExpression(expression);
+        }
+    }
+}

--- a/Dapper.Extensions.Linq/Builder/QueryBuilder.cs
+++ b/Dapper.Extensions.Linq/Builder/QueryBuilder.cs
@@ -219,6 +219,9 @@ namespace Dapper.Extensions.Linq.Builder
                     case ExpressionType.Call:
                         return this.ParseCall((MethodCallExpression)expression);
 
+                    case ExpressionType.MemberAccess:
+                        return this.ParseBoolMember((MemberExpression) expression);
+
                     case ExpressionType.Add:
                     case ExpressionType.AddAssign:
                     case ExpressionType.AddAssignChecked:
@@ -254,7 +257,6 @@ namespace Dapper.Extensions.Linq.Builder
                     case ExpressionType.LeftShiftAssign:
                     case ExpressionType.ListInit:
                     case ExpressionType.Loop:
-                    case ExpressionType.MemberAccess:
                     case ExpressionType.MemberInit:
                     case ExpressionType.Modulo:
                     case ExpressionType.ModuloAssign:
@@ -300,6 +302,17 @@ namespace Dapper.Extensions.Linq.Builder
                     case ExpressionType.Constant:
                         return new PredicateGroup();
                 }
+            }
+
+            private IPredicate ParseBoolMember(MemberExpression expression)
+            {
+                if (expression.Type == typeof (bool))
+                {
+                    var propertyName = expression.Member.Name;
+                    return new FieldPredicate<T> { Not = false, Operator = Operator.Eq, PropertyName = propertyName, Value = true };
+                }
+
+                throw new NotImplementedException(expression.Type.ToString());
             }
 
             private IPredicate ParseCall(MethodCallExpression expression)


### PR DESCRIPTION
While converting my old queries to Dapper linq I've run into an issue parsing expressions like:
`Expression<Func<Person, bool>> expression = e => e.Id == 14 && e.Active;`

The quick fix to make Dapper handle it is to rewrite it as:
`Expression<Func<Person, bool>> expression = e => e.Id == 14 && e.Active == true;`

But ReSharper complains about such things and following its refactoring suggestions would break the query.
This is why I've enhaced the QueryBuilder to handle this case.
