### PR TITLE
Handling NullReferenceException when comparing against MemberExpressi…

### DIFF
--- a/Dapper.Extensions.Linq.Test/IntegrationTests/Fixtures/QueryBuilder.cs
+++ b/Dapper.Extensions.Linq.Test/IntegrationTests/Fixtures/QueryBuilder.cs
@@ -36,5 +36,13 @@ namespace Dapper.Extensions.Linq.Test.IntegrationTests.Fixtures
 
             QueryBuilder<Person>.FromExpression(expression);
         }
+
+        [Test]
+        public void QueryBuilder_LeftSideMemberExpression()
+        {
+            Expression<Func<Person, bool>> expression = e => DateTime.Now == e.DateCreated && e.Active;
+
+            QueryBuilder<Person>.FromExpression(expression);
+        }
     }
 }

--- a/Dapper.Extensions.Linq/Builder/QueryBuilder.cs
+++ b/Dapper.Extensions.Linq/Builder/QueryBuilder.cs
@@ -462,7 +462,7 @@ namespace Dapper.Extensions.Linq.Builder
             if (expression.NodeType == ExpressionType.MemberAccess)
             {
                 var memberExpression = expression as MemberExpression;
-                if (memberExpression.Expression.NodeType == ExpressionType.Parameter)
+                if (memberExpression?.Expression?.NodeType == ExpressionType.Parameter)
                 {
                     name = memberExpression.Member.Name;
                     return true;


### PR DESCRIPTION
Let's see if you also knew this one.
It happens whenever you have a method call on the left side of a comparison.

``` C#
Expression<Func<Person, bool>> expression = e => DateTime.Now == e.DateCreated && e.Active;
```

This is the last issue I've found, but using this extension is so much fun, that I'll surely keep looking for more. :)
